### PR TITLE
Add 'Why This Approach' section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ Talk with AI to generate market research, business plans, product requirements (
 5. **Pitch deck** → Presentation slides (Marp format, exportable to PDF/PowerPoint)
 6. **Decision tracking** → Extracts insights from meetings to improve your next plan
 
+## Why This Approach
+
+Traditional planning: perfect the plan → build → get feedback.
+
+With AI tools, building prototypes takes hours instead of months.
+
+**Rough hypothesis → Prototype → User feedback → Refine the plan**
+
+This tool doesn't aim to produce "perfect" business plans.
+Instead, it helps you:
+- Organize testable hypotheses quickly
+- Make clear what still needs validation
+- Identify critical assumptions to verify first
+- Get to user feedback faster
+
+A plan with clear gaps isn't incomplete—it shows exactly what to test next.
+
 ## Who This Is For
 
 **Business professionals who use AI tools but aren't technical experts.**


### PR DESCRIPTION
## Summary

- Add new section explaining the tool's hypothesis-driven planning philosophy
- Position between "What This Tool Does" and "Who This Is For"
- Clarify that clear gaps in plans show what to test next, not incompleteness

## Context

With AI tools reducing prototype costs (hours instead of months), the value shifts from creating "perfect" business plans to:
- Organizing testable hypotheses quickly
- Making clear what still needs validation
- Getting to user feedback faster

This sets appropriate expectations for users and differentiates the tool's approach.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm new section flows naturally between existing sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)