### PR TITLE
Add atmosphere translation to prompt generation workflow

### DIFF
--- a/.agents/rules/business/prompt-engineering.md
+++ b/.agents/rules/business/prompt-engineering.md
@@ -26,6 +26,36 @@ Best practices for crafting effective prompts for AI-powered prototype generatio
 - Visual style and tone
 - Layout approach and color semantics
 
+### 5. Atmosphere Specification
+
+When design specification exists, include concrete visual instructions derived from atmosphere keywords.
+
+**Required elements:**
+- Atmosphere keywords
+- Color palette with hex values
+- Border-radius, shadow, spacing direction
+- Override instructions for default UI library styles
+- Elements to avoid
+
+**Platform-specific overrides:**
+
+For v0 (shadcn/ui based):
+```
+Override shadcn/ui defaults:
+- Colors: [custom palette replacing slate/gray]
+- Border-radius: [value]
+- Shadows: [style]
+- Spacing: [direction]
+```
+
+For Genspark:
+```
+Design customization:
+- Color palette: [hex values]
+- Visual atmosphere: [keywords]
+- Avoid: [specific elements]
+```
+
 ## Prompt Structure Template
 
 ### Essential Sections
@@ -79,6 +109,8 @@ Best practices for crafting effective prompts for AI-powered prototype generatio
 - Provide mock data examples
 - Describe component interactions
 - Specify responsive requirements
+- Include atmosphere keywords and color palette
+- Specify overrides from default styling
 
 **Example Pattern:**
 ```
@@ -112,10 +144,14 @@ Interactions: [Click, hover, form states]
 ```
 Build [component] used by [user role] in [scenario] to [decision/action].
 
-Design: [style] with [color semantics]
-Layout: [responsive approach]
+Atmosphere: [keywords]
+Color palette: [hex values]
+
+Override shadcn/ui defaults:
+- [specific overrides]
+
 Components:
-- [Component]: [behavior description]
+- [Component]: [behavior]
 
 Interactions: [state changes on user actions]
 ```

--- a/.agents/tasks/design-specification.md
+++ b/.agents/tasks/design-specification.md
@@ -32,6 +32,16 @@ Define design requirements and specifications for prototype, including UI/UX con
 - User flow considerations
 - Usability goals
 
+### 2.5 Atmosphere Translation
+
+Translate abstract brand/industry attributes into concrete design elements.
+
+**Required outputs:**
+- 3-5 atmosphere keywords from business plan
+- Design direction for: colors, border-radius, shadows, spacing, typography
+- Reference materials (URLs, images) if available
+- Elements to avoid
+
 ### 3. Visual Design
 - Color palette
 - Typography
@@ -96,6 +106,11 @@ Define design requirements and specifications for prototype, including UI/UX con
 - [ ] Brand personality (if not in business plan)
 - [ ] Design references or inspiration (if any)?
 - [ ] Specific design constraints or preferences?
+
+**Atmosphere** (SHOULD HAVE):
+- [ ] Atmosphere keywords (3-5 adjectives describing brand/industry feel)
+- [ ] Design references or inspiration
+- [ ] Elements to avoid
 
 **Visual Elements** (SHOULD HAVE):
 - [ ] Color preferences or brand colors?

--- a/.agents/tasks/prompt-generation.md
+++ b/.agents/tasks/prompt-generation.md
@@ -124,12 +124,17 @@ Pure prompt specifications → `v0-prompt.md`
 - Data requirements
 - Integration points (if any)
 
-### 5. Design Requirements (if applicable)
-- UI/UX guidelines
-- Visual design preferences
-- Brand elements
-- Accessibility requirements
-- Responsive design needs
+### 5. Design Requirements
+
+When design specification exists:
+- Atmosphere keywords and translated design elements
+- Color palette with hex values
+- Override instructions for UI library defaults
+- Elements to avoid
+
+When design specification does not exist:
+- Extract industry characteristics from business plan
+- Define minimal atmosphere direction
 
 ### 6. Technical Preferences
 - Platform (web, mobile, PWA, etc.)
@@ -237,11 +242,16 @@ Generate platform-specific prompt using guidelines from Section "Platform-Specif
 - Understand user flows
 - Note constraints and preferences
 
-### Step 2: Design Integration (if applicable)
-- Review design requirements
-- Extract key design elements
-- Identify UI/UX patterns
-- Note brand guidelines
+### Step 2: Design Integration
+
+If design specification exists:
+- Extract atmosphere keywords and design translations
+- Confirm color palette with hex values
+- Identify required UI library overrides
+
+If design specification does not exist:
+- Extract industry characteristics from business plan
+- Set minimal atmosphere keywords
 
 ### Step 3: Generic Prompt Creation
 - Write comprehensive, platform-agnostic prompt
@@ -334,11 +344,23 @@ Before writing each file, apply the Decision Test from Section 2.6:
 - [Requirement 2]
 [...]
 
-## Design Requirements (if applicable)
-- UI/UX: [guidelines]
-- Visual style: [preferences]
-- Brand: [elements]
-- Responsive: [requirements]
+## Design Requirements
+
+### Atmosphere
+- Keywords: [3-5 adjectives]
+- Avoid: [elements]
+
+### Visual Specifications
+- Colors: Primary #[hex], Secondary #[hex], Accent #[hex]
+- Border-radius: [direction]
+- Shadows: [direction]
+- Spacing: [direction]
+
+### UI Library Overrides
+[Platform-specific override instructions]
+
+### Responsive
+- [requirements]
 
 ## Technical Preferences
 - Platform: [web/mobile/etc]
@@ -362,6 +384,8 @@ Before writing each file, apply the Decision Test from Section 2.6:
 □ All MVP features included in prompt files
 □ User flows clearly described in prompts
 □ Design requirements integrated (if applicable)
+□ Atmosphere reflected as concrete design elements
+□ UI library override instructions included (for v0/Genspark)
 □ Success criteria defined in prompts
 □ Prompts ready for direct copy-paste into AI tools
 


### PR DESCRIPTION
## Summary

- Add atmosphere translation process to design specification
- Add atmosphere specification section to prompt engineering rules
- Include UI library override instructions for v0 (shadcn/ui) and Genspark
- Update prompt templates with atmosphere keywords and visual specifications
- Ensure brand/industry feel is reflected in generated prototypes

This addresses the issue where generated prototypes have a generic "SaaS template" feel instead of reflecting the specific brand/industry atmosphere.

## Test plan

- [ ] Run prompt generation workflow with design specification
- [ ] Verify atmosphere keywords are extracted and included in prompts
- [ ] Confirm UI library override instructions are present in generated prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)